### PR TITLE
feat: add variants for customizing scrollbar

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,10 @@ const tags = [
 export const creator: PluginCreator = (configApi) => {
     const { addVariant } = configApi
     tags.forEach(tag => addVariant(tag, `:where(&:is(${tag}), & > ${tag})`))
+
+    addVariant("scroll", "&::-webkit-scrollbar")
+    addVariant("thumb", "&::-webkit-scrollbar-thumb")
+    addVariant("track", "&::-webkit-scrollbar-track")
 }
 
 export default plugin(creator)


### PR DESCRIPTION
## Feat: add scrollbar customization variants

This Pull Request introduces new variants for customizing the scrollbar styles using the `::-webkit-` prefix and properties. The variants have been added:

-  `scroll`: for styling the scrollbar
-  `thumb`: for stylig the scrollbar-thumb
-  `track`: for styling the scrollbar-track