### PR TITLE
Feat/fluency: add font size utilities

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,9 +34,74 @@ const tags = [
     "footer"
 ]
 
+
+const fontSizeUtilities: Record<string, Record<string, string>> = {
+    "xs": {
+        fontSize: "clamp(0.75rem, 1.5vw, 1rem)",
+        lineHeight: "1.25rem",
+        letterSpacing: "0.05em",
+    },
+    "sm": {
+        fontSize: "clamp(0.875rem, 1.5vw, 1.125rem)",
+        lineHeight: "1.375rem",
+        letterSpacing: "0.025em"
+    },
+    "base": {
+        fontSize: "clamp(1rem, 2vw, 1.25rem)",
+        lineHeight: "1.5rem",
+        letterSpacing: "0em"
+    },
+    "lg": {
+        fontSize: "clamp(1.125rem, 2.5vw, 1.5rem)",
+        lineHeight: "1.75rem",
+        letterSpacing: "-0.005em"
+    },
+    "xl": {
+        fontSize: "clamp(1.25rem, 3vw, 1.75rem)",
+        lineHeight: "1.875rem",
+        letterSpacing: "-0.01em"
+    },
+    "2xl": {
+        fontSize: "clamp(1.5rem, 4vw, 2rem)",
+        lineHeight: "2rem",
+        letterSpacing: "-0.015em"
+    },
+    "3xl": {
+        fontSize: "clamp(1.875rem, 5vw, 2.5rem)",
+        lineHeight: "2.25rem",
+        letterSpacing: "-0.02em"
+    },
+    "4xl": {
+        fontSize: "clamp(2.25rem, 6vw, 3rem)",
+        lineHeight: "2.5rem",
+        letterSpacing: "-0.025em"
+    },
+    "5xl": {
+        fontSize: "clamp(3rem, 7vw, 3.5rem)",
+        lineHeight: "1",
+        letterSpacing: "-0.03em"
+    },
+    "6xl": {
+        fontSize: "clamp(3.75rem, 8vw, 4.5rem)",
+        lineHeight: "1",
+        letterSpacing: "-0.035em"
+    },
+};
+
+
 export const creator: PluginCreator = (configApi) => {
-    const { addVariant } = configApi
+    const { addVariant, addUtilities, e } = configApi
     tags.forEach(tag => addVariant(tag, `:where(&:is(${tag}), & > ${tag})`))
+
+    const entries: Record<string, Record<string, string>> = {}
+    Object.keys(fontSizeUtilities).forEach(key => {
+        entries[`.${e(`fluency-${key}`)}`] = {
+            "font-size": fontSizeUtilities[key]["fontSize"],
+            "line-height": fontSizeUtilities[key]["lineHeight"],
+            "letter-spacing": fontSizeUtilities[key]["letterSpacing"]
+        }
+    })
+    addUtilities(entries)
 }
 
 export default plugin(creator)


### PR DESCRIPTION
## Feat: add font size utility

This pull request introduces a new utility class called "fluency" that dynamically adjusts the font size of tags based on the viewport size. It utilizes the CSS `clamp` function to generate the font size dynamically. These utilities are designed to work seamlessly with the variants available in TailwindCSS.

## Caveats

At the moment, these utilities do not support changing the values in the same place.

## Utilities

- `fluency-xs`
- `fluency-sm`
- `fluency-base`
- `fluency-lg`
- `fluency-xl`
- `fluency-2xl`
- `fluency-3xl`
- `fluency-4xl`
- `fluency-5xl`
- `fluency-6xl`

## Test

The following image illustrates an example of how the utilities work:

![image](https://github.com/halvaradop/tailwindcss-flow/assets/105169289/cd1c18f0-dd74-442a-bfea-eff144b867b7)

## Checklist:

- [ ] Docs
- [x] The changes don't generate warnings
- [x] I have performed a self-review of my own code
- [ ] Test
