### PR TITLE
feat: add functionality to extends selectors/tags from configuration

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,8 @@
+
+export class InvalidSelectorError extends Error {
+
+    constructor(message: string) {
+        super(message)
+        this.name = "InvalidSelectorError"
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
 import plugin from "tailwindcss/plugin"
 import { PluginCreator } from "tailwindcss/types/config"
+import { EntryCSS, FontFluency } from "./types";
+import { verifySelectorsTheme } from "./utils";
+
 
 const tags = [
     "div",
@@ -35,7 +38,7 @@ const tags = [
 ]
 
 
-const fontSizeUtilities: Record<string, Record<string, string>> = {
+const fontSizeUtilities: Record<string, EntryCSS<FontFluency>> = {
     "xs": {
         fontSize: "clamp(0.75rem, 1.5vw, 1rem)",
         lineHeight: "1.25rem",
@@ -90,8 +93,10 @@ const fontSizeUtilities: Record<string, Record<string, string>> = {
 
 
 export const creator: PluginCreator = (configApi) => {
-    const { addVariant, addUtilities, e } = configApi
-    tags.forEach(tag => addVariant(tag, `:where(&:is(${tag}), & > ${tag})`))
+    const { addVariant, addUtilities, e, theme } = configApi
+
+    const selectors = verifySelectorsTheme(theme("selectors")).concat(tags)
+    selectors.forEach(tag => addVariant(tag, `:where(&:is(${tag}), & > ${tag})`))
 
     const entries: Record<string, Record<string, string>> = {}
     Object.keys(fontSizeUtilities).forEach(key => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,3 @@
+
+export type FontFluency = Pick<CSSStyleDeclaration, "fontSize" | "lineHeight" | "letterSpacing">
+export type EntryCSS<Key = string, Value = string> = Key extends string ? Record<string, Value> : Record<keyof Key, Value>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,11 @@
+import { InvalidSelectorError } from "./errors"
+
+export const tagRegex = /^([a-z]{1,}\-?){1,}$/
+
+export const verifySelectorsTheme = (selectors: string[] = []): string[] => {
+    const haveInvalid = selectors.some(selector => !tagRegex.test(selector))
+    if(haveInvalid) {
+        throw new InvalidSelectorError("Invalid tag html, you must the verify the tags")
+    }
+    return selectors
+}


### PR DESCRIPTION
## Description
This pull request introduces a new functionality that allows users to extend the selectors/tags provided by the `@halvaradop/tailwindcss-flow` plugin. Users can add new tags through the Tailwind CSS configuration file.

## Motivation
Extending the selectors/tags functionality enhances the plugin's versatility and customization options for users. It allows developers to access and apply utility classes to additional tags that are not supported by default, increasing the plugin's flexibility and usability.

## Usage
To extend the selectors/tags, users need to add the new tags inside the `theme` property within the Tailwind CSS configuration file. The new tags should be included in an array. Users must ensure that the tags are correctly structured and named, otherwise an error will be returned.

```ts
import type { Config } from "tailwindcss";

const config: Config = {
  content: [],
  theme: {
     selectors: ["menu", "aside"]
  },
  plugins: [],
};

export default config;
```


## Checklist:
- [ ] Documentation
- [x] The changes don't generate warnings
- [x] I have performed a self-review of my own code
- [ ]  Test