### PR TITLE
refactor: split the scrollbar utility variants in a separate file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import plugin from "tailwindcss/plugin"
 import { PluginCreator } from "tailwindcss/types/config"
 import { EntryCSS, FontFluency } from "./types";
 import { verifySelectorsTheme } from "./utils";
+import { scrollUtilities } from "./scroll-utilities";
 
 
 const tags = [
@@ -107,10 +108,7 @@ export const creator: PluginCreator = (configApi) => {
         }
     })
     addUtilities(entries)
-    
-    addVariant("scroll", "&::-webkit-scrollbar")
-    addVariant("thumb", "&::-webkit-scrollbar-thumb")
-    addVariant("track", "&::-webkit-scrollbar-track")
+    scrollUtilities(configApi)
 }
 
 export default plugin(creator)

--- a/src/scroll-utilities.ts
+++ b/src/scroll-utilities.ts
@@ -1,0 +1,16 @@
+import { PluginAPI } from "tailwindcss/types/config";
+
+/**
+ * Defines a set of variants to customize the scrollbar of a component or
+ * element that presents overflow. These variants support the standard TailwindCSS
+ * variants like :hover, :focus, and others.
+ * 
+ * @param configApi The configuration API object obtained from tailwindcss.config.ts
+ */
+export const scrollUtilities = (configApi: PluginAPI) => {
+    const { addVariant } = configApi
+
+    addVariant("scroll", "&::-webkit-scrollbar")
+    addVariant("thumb", "&::-webkit-scrollbar-thumb")
+    addVariant("track", "&::-webkit-scrollbar-track")
+}


### PR DESCRIPTION
## Description
This pull request refactors the code by encapsulating the scrollbar variant utilities in a separate function and moving them to their own file. This separation improves the organization and readability of the code by grouping related functionalities together.

## Motivation
This change improves code organization and readability by grouping related functionalities, making the codebase easier to maintain and understand.

## Checklist
- [x] Documentation
- [x]  The changes don't generate warnings
- [x]  I have performed a self-review of my own code
- [ ]  Test