### PR TITLE
refactor: separete the selector utilities function and clean the entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "tailwindcss-flow",
-  "version": "0.0.8",
-  "description": "Is a plugin designed to improve productivity in application development by providing additional utilities.",
+  "name": "@halvaradop/tailwindcss-flow",
+  "version": "0.0.1",
+  "description": "A TailwindCSS plugin that provides a set of utilities to enhance the default functionalities and offer additional customization options.",
   "main": "src/index.ts",
   "types": "src/index.d.ts",
   "scripts": {
@@ -10,7 +10,8 @@
     "build": "tsc && npm run build:css"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/@halvaradop/tailwindcss-flow@0.0.1"
   },
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,50 +1,17 @@
 import plugin from "tailwindcss/plugin"
 import { PluginCreator } from "tailwindcss/types/config"
-import { verifySelectorsTheme } from "./utils";
 import { scrollUtilities } from "./scroll-utilities";
 import { fluencyUtilities } from "./fluency-utilities";
+import { selectorUtilities } from "./selector-utilities";
 
-
-const tags = [
-    "div",
-    "span",
-    "a",
-    "p",
-    "img",
-    "h1",
-    "h2",
-    "h3",
-    "h4",
-    "h5",
-    "h6",
-    "ul",
-    "ol",
-    "li",
-    "table",
-    "tr",
-    "td",
-    "form",
-    "input",
-    "button",
-    "section",
-    "main",
-    "body",
-    "article",
-    "label",
-    "img",
-    "figure",
-    "picture",
-    "caption",
-    "footer"
-]
-
-
+/**
+ * Entry point of the application. This encapsulates the utilities offered
+ * by the plugin.
+ * 
+ * @param configApi The configuration API object obtained from tailwindcss.config.ts
+ */
 export const creator: PluginCreator = (configApi) => {
-    const { addVariant, theme } = configApi
-
-    const selectors = verifySelectorsTheme(theme("selectors")).concat(tags)
-    selectors.forEach(tag => addVariant(tag, `:where(&:is(${tag}), & > ${tag})`))
-
+    selectorUtilities(configApi)
     fluencyUtilities(configApi)
     scrollUtilities(configApi)
 }

--- a/src/selector-utilities.ts
+++ b/src/selector-utilities.ts
@@ -1,0 +1,57 @@
+import { PluginAPI } from "tailwindcss/types/config"
+import { verifySelectorsTheme } from "./utils"
+
+/**
+ * This array contains the default tags supported by the selector variant
+ * utilities. It provides a list of commonly used tags.
+ */
+const tags: string[] = [
+    "div",
+    "span",
+    "a",
+    "p",
+    "img",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "ul",
+    "ol",
+    "li",
+    "table",
+    "tr",
+    "td",
+    "form",
+    "input",
+    "button",
+    "section",
+    "main",
+    "body",
+    "article",
+    "label",
+    "img",
+    "figure",
+    "picture",
+    "caption",
+    "footer"
+]
+
+
+/**
+ * Defines a set of tag variant utilities that allow you to customize different
+ * HTML tags within a project. This enables more specific styling of elements.
+ * The plugin also allows users to extend the default set of supported tags.
+ * 
+ * To extend the default tags, you can add an array of new tags within the theme 
+ * property and set a `selectors` property in the Tailwind configuration file.
+ * 
+ * @param configApi The configuration API object obtained from tailwindcss.config.ts
+ */
+export const selectorUtilities = (configApi: PluginAPI) => {
+    const { addVariant, theme } = configApi
+    
+    const selectors = verifySelectorsTheme(theme("selectors")).concat(tags)
+    selectors.forEach(tag => addVariant(tag, `:where(&:is(${tag}), & > ${tag})`))
+}

--- a/src/utilities.css
+++ b/src/utilities.css
@@ -1,3 +1,0 @@
-@tailwind base;
-@tailwind utilities;
-@tailwind components;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "ES2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
@@ -106,5 +106,7 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */,
-  }
+  },
+  "include": ["src/"],
+  "exclude": ["src/page"]
 }


### PR DESCRIPTION
## Description
This pull request refactors the code by separating the selector variant utilities from the main entry point, improving the structure and readability of the project, and removing unused code to reduce the package size. The changes introduced are:

- `Selector utilities`: Split the code into its own file to separate responsibilities
- `Entry point`: Cleaned up the main entry point of the application, encapsulating utilities and logic.
- `Clean up`: Removed unused code from the project.

## Motivation
These changes aim to improve the codebase of the application by enhancing maintainability and readability.

## Checklist
- [x]  Documentation
- [x]  The changes don't generate warnings
- [x]  I have performed a self-review of my own code
- [ ]  Test