### PR TITLE
feat: extend fluency utilities and add function to clean/remove empty properties

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,3 +18,28 @@ export const verifySelectorsTheme = (selectors: string[] = []): string[] => {
     }
     return selectors
 }
+
+
+/**
+ * Removes properties with empty values from an object to clean it up. It verifies if 
+ * the values are:
+ *  - an empty string
+ *  - null
+ *  - undefined
+ *  - an empty array
+ *  - an empty object
+ * 
+ * @param entry An object to clean up by removing empty properties.
+ * @returns The cleaned object.
+ */
+export const removeEmptyProperties = <T extends Record<string, any>>(entry: T) => {
+    for(const key in entry) {
+        const pairValue = entry[key]
+        const isArray = Array.isArray(pairValue)
+        const isObject = pairValue && typeof pairValue === "object" && !isArray
+        if((!pairValue) || pairValue === "" || (isArray && !pairValue.length) || (isObject && !Object.keys(pairValue).length)) {
+            delete entry[key]
+        }
+    }
+    return entry
+};


### PR DESCRIPTION
## Descripton
This pull request introduces a new feature that allows users to extend or update the default values offered by the plugin with the fluency utilities, which can be changed in the configuration file. Additionally, it includes a new function to remove empty properties from an object.

- `Fluency utilities`: Extend the default values or overwrite existing utilities through the theme configuration.
- `Remove empty properties`: Implemented a function to clean up the properties of an object with empty values.

## Motivatin
These changes aim to improve and provide flexibility and customization offered by the plugin with the fluency utilities, ensuring cleaner utility objects.

## Checklist
- [x]  Documentation
- [x]  The changes don't generate warnings
- [x]  I have performed a self-review of my own code
- [ ]  Test