### PR TITLE
feat: add new pseudo-classes utilities

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { PluginCreator } from "tailwindcss/types/config"
 import { scrollUtilities } from "./scroll-utilities";
 import { fluencyUtilities } from "./fluency-utilities";
 import { selectorUtilities } from "./selector-utilities";
+import { pseudoClassesUtilities } from "./pseudo-classes-utilities";
 
 /**
  * Entry point of the application. This encapsulates the utilities offered
@@ -14,6 +15,7 @@ export const creator: PluginCreator = (configApi) => {
     selectorUtilities(configApi)
     fluencyUtilities(configApi)
     scrollUtilities(configApi)
+    pseudoClassesUtilities(configApi)
 }
 
 export default plugin(creator)

--- a/src/pseudo-classes-utilities.ts
+++ b/src/pseudo-classes-utilities.ts
@@ -1,0 +1,16 @@
+import { PluginAPI } from "tailwindcss/types/config";
+
+/**
+ * Defines a set of variant utilities for grouping elements and customizing 
+ * them in an easy way to create powerful classes and increase the specificity 
+ * of the elements.
+ * 
+ * @param configApi The configuration API object obtained from tailwindcss.config.ts
+ */
+export const pseudoClassesUtilities = (configApi: PluginAPI) => {
+    const { matchVariant } = configApi
+
+    matchVariant("is", value => `&:is(${value})`)
+    matchVariant("not", value => `&:not(${value})`)
+    matchVariant("where", value => `&:where(${value})`)
+}


### PR DESCRIPTION
## Description
This pull request introduces a new set of variant utilities for grouping elements to match with a list of CSS rules, improving specificity and enabling easy customization of elements based on their tags, attributes, or specific rules.

- `pseudo classes`: Adds variants for is, not, and where pseudo-classes.

## Motivation
The motivation behind these changes is to extend the utilities offered by the plugin, allowing for greater customization of the UI without worrying about the classes.

## Checklist
- [x]  Documentation
- [x]  The changes don't generate warnings
- [x]  I have performed a self-review of my own code
- [ ]  Test