### PR TITLE
chore: add default values for min-width theme utilities and release a new version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/tailwindcss-flow",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A TailwindCSS plugin that provides a set of utilities to enhance the default functionalities and offer additional customization options.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { scrollUtilities } from "./scroll-utilities";
 import { fluencyUtilities } from "./fluency-utilities";
 import { selectorUtilities } from "./selector-utilities";
 import { pseudoClassesUtilities } from "./pseudo-classes-utilities";
+import { minWidthUtilities } from "./min-width-utilities";
 
 /**
  * Entry point of the application. This encapsulates the utilities offered
@@ -18,4 +19,8 @@ export const creator: PluginCreator = (configApi) => {
     pseudoClassesUtilities(configApi)
 }
 
-export default plugin(creator)
+export default plugin(creator, {
+    theme: {
+        minWidth: minWidthUtilities
+    }
+})

--- a/src/min-width-utilities.ts
+++ b/src/min-width-utilities.ts
@@ -1,0 +1,17 @@
+import { Config } from "tailwindcss";
+
+/**
+ * Defines default values for the minWidth theme in TailwindCSS.
+ * It provides a set of predefined minimum widths.
+ */
+export const minWidthUtilities: Partial<Config> = {
+    theme: {
+        minWidth: {
+            sm: "640px",
+            md: "768px",
+            lg: "1024px",
+            xl: "1280px",
+            "2xl": "1526px"
+        }
+    }
+}


### PR DESCRIPTION
## Description
This pull request introduces definitions for min-width utilities that can be accessed from the configuration file. Additionally, it includes changes from the latest version published for the package.

- `Release`:  A new version of the package has been published, incorporating the latest changes.
- `Min-width utilities`:  Added predefined values to specify the minimum width of a component.


## Checklist
- [x] Documentation.
- [x] The changes don't generate warnings.
- [x] I have performed a self-review of my own code.
- [ ] Test.